### PR TITLE
rename to ImageBase and reexport ImageCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 
 [deps]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 ImageCore = "0.8, 0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "ImageUtils"
+name = "ImageBase"
 uuid = "c817782e-172a-44cc-b673-b171935fbb9e"
 version = "0.1.0"
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# ImageUtils
+# ImageBase
 
-[![Build Status](https://github.com/JuliaImages/ImageUtils.jl/workflows/CI/badge.svg)](https://github.com/JuliaImages/ImageUtils.jl/actions)
-[![Coverage](https://codecov.io/gh/JuliaImages/ImageUtils.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaImages/ImageUtils.jl)
+[![Build Status](https://github.com/JuliaImages/ImageBase.jl/workflows/CI/badge.svg)](https://github.com/JuliaImages/ImageBase.jl/actions)
+[![Coverage](https://codecov.io/gh/JuliaImages/ImageBase.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaImages/ImageBase.jl)
 
 This is a twin package to [ImageCore] with functions that are used among many of the packages in JuliaImages.
 The main purpose of this package is to reduce unnecessary compilation overhead from external dependencies.
+
+This package reexports [ImageCore] so can be a direct replacement of it.
 
 This package can be seen as an experimental package inside JuliaImages:
 

--- a/src/ImageBase.jl
+++ b/src/ImageBase.jl
@@ -1,4 +1,4 @@
-module ImageUtils
+module ImageBase
 
 export restrict
 

--- a/src/ImageBase.jl
+++ b/src/ImageBase.jl
@@ -2,8 +2,10 @@ module ImageBase
 
 export restrict
 
+using Reexport
+
 using Base.Cartesian: @nloops
-using ImageCore
+@reexport using ImageCore
 using ImageCore.OffsetArrays
 
 include("restrict.jl")

--- a/src/restrict.jl
+++ b/src/restrict.jl
@@ -35,7 +35,7 @@ restrict(A, (1, 2)) # size: (3, 3)
 Unless the input array is 1-based, the origin will be halfed:
 
 ```julia
-julia> using ImageUtils, OffsetArrays
+julia> using ImageBase, OffsetArrays
 
 julia> Ao = OffsetArray(rand(5, 4), 5, 6);
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
-using ImageUtils, ImageCore, OffsetArrays
+using ImageBase, ImageCore, OffsetArrays
 using Test, TestImages
 
-@testset "ImageUtils.jl" begin
+@testset "ImageBase.jl" begin
     include("restrict.jl")
 
     @info "deprecations are expected"


### PR DESCRIPTION
Unfortunately, there's a name conflict to https://github.com/tknopp/ImageUtils.jl

Hence here I rename it to ImageBase, to indicate that this is a package built on top of ImageCore. I also reexport `ImageCore` for convenience.