### PR TITLE
`restrict`: better offset support

### DIFF
--- a/test/restrict.jl
+++ b/test/restrict.jl
@@ -83,7 +83,7 @@
         @test xr == restrict(x)
         @test xr isa Array
 
-        x = view(x0, Base.IdentityUnitRange(3:5))
+        x = view(x0, IdentityUnitRange(3:5))
         xr = restrict(x)
         @test xr == restrict(collect(x))
         @test xr isa Array

--- a/test/restrict.jl
+++ b/test/restrict.jl
@@ -75,6 +75,20 @@
         end
     end
 
+    @testset "SubArray" begin
+        x0 = [0, 0, 1, 1, 0, 0]
+        xv = @view x0[1:2:6]
+        x = x0[1:2:6]
+        xr = restrict(xv)
+        @test xr == restrict(x)
+        @test xr isa Array
+
+        x = view(x0, Base.IdentityUnitRange(3:5))
+        xr = restrict(x)
+        @test xr == restrict(collect(x))
+        @test xr isa Array
+    end
+
     @testset "FixedPoint overflow" begin
         # issue https://github.com/JuliaImages/Images.jl/issues/395
         img1 = colorview(RGB, fill(0.9, 3, 5, 5))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using ImageBase, ImageCore, OffsetArrays
 using Test, TestImages
 
+using OffsetArrays: IdentityUnitRange
+
 @testset "ImageBase.jl" begin
     include("restrict.jl")
 


### PR DESCRIPTION
Two things are included in this PR:

1. relax `require_one_based_indexing` constrain via eagerly `collect`; this helps handle edge cases such as `SubArray` with offsets and others.
2. `OffsetArray` performance was not good because there was unnecessary offset computation in the internal for loop. By eagerly convert it to the non-offsetted array before passing to `restrict`, the overhead is removed.

```julia
using ImageBase, TestImages, OffsetArrays

img = testimage("camera");
imgo = OffsetArray(img, -1, -1);

@btime restrict($img);
# 90.136 μs (10 allocations: 772.31 KiB)

@btime restrict($imgo);
# master: 211.889 μs (14 allocations: 772.53 KiB)
# PR: 89.594 μs (10 allocations: 772.31 KiB)
```
  