### PR TITLE
Add finite difference: `fdiff` and `fdiff!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,10 +12,14 @@ Reexport = "0.2, 1"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+StackViews = "cae243ae-269e-4f55-b966-ac2d0dc13c15"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Test", "ImageMagick", "OffsetArrays", "TestImages"]
+test = ["Aqua", "Documenter", "Test", "ImageIO", "ImageMagick", "OffsetArrays", "StackViews", "TestImages"]

--- a/README.md
+++ b/README.md
@@ -14,4 +14,10 @@ This package can be seen as an experimental package inside JuliaImages:
 2. is very conservative to external dependencies outside JuliaImages unless there is a real need, in which case,
    it may just fit the first case.
 
+Functions provided by this package:
+
+- `restrict` for two-fold image downsample. (Originally from ImageTransformations.jl)
+- finite difference operator `fdiff`/`fdiff!` (Originally from Images.jl)
+
+
 [ImageCore]: https://github.com/JuliaImages/ImageCore.jl

--- a/src/ImageBase.jl
+++ b/src/ImageBase.jl
@@ -8,6 +8,7 @@ using Base.Cartesian: @nloops
 @reexport using ImageCore
 using ImageCore.OffsetArrays
 
+include("diff.jl")
 include("restrict.jl")
 include("compat.jl")
 include("deprecated.jl")

--- a/src/ImageBase.jl
+++ b/src/ImageBase.jl
@@ -1,6 +1,15 @@
 module ImageBase
 
-export restrict
+export
+    # two-fold downsampling
+    # originally from ImageTransformations.jl
+    restrict,
+
+    # finite difference on one-dimension
+    # originally from Images.jl
+    fdiff,
+    fdiff!
+
 
 using Reexport
 

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -3,3 +3,7 @@ if VERSION < v"1.2"
 else
     const require_one_based_indexing = Base.require_one_based_indexing
 end
+
+if VERSION < v"1.1"
+    isnothing(x) = x === nothing
+end

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -1,0 +1,215 @@
+function forwarddiff(a::AbstractArray{T,N}; dims::Int) where {T,N}
+    require_one_based_indexing(a)
+    1 <= dims <= N || throw(ArgumentError("dimension $dims out of range (1:$N)"))
+
+    d = similar(a)
+    r = axes(a)
+    r0 = ntuple(i -> i == dims ? UnitRange(1, last(r[i]) - 1) : UnitRange(r[i]), N)
+    r1 = ntuple(i -> i == dims ? UnitRange(2, last(r[i])) : UnitRange(r[i]), N)
+
+    d0 = ntuple(i -> i == dims ? UnitRange(last(r[i]), last(r[i])) : UnitRange(r[i]), N)
+    d1 = ntuple(i -> i == dims ? UnitRange(1, 1) : UnitRange(r[i]), N)
+
+    d[r0...] = view(a, r1...) .- view(a, r0...)
+    d[d0...] = view(a, d1...) .- view(a, d0...)
+
+    return d
+end
+
+function backdiff(a::AbstractArray{T,N}; dims::Int) where {T,N}
+    require_one_based_indexing(a)
+    1 <= dims <= N || throw(ArgumentError("dimension $dims out of range (1:$N)"))
+
+    d = similar(a)
+    r = axes(a)
+    r0 = ntuple(i -> i == dims ? UnitRange(1, last(r[i]) - 1) : UnitRange(r[i]), N)
+    r1 = ntuple(i -> i == dims ? UnitRange(2, last(r[i])) : UnitRange(r[i]), N)
+
+    d0 = ntuple(i -> i == dims ? UnitRange(last(r[i]), last(r[i])) : UnitRange(r[i]), N)
+    d1 = ntuple(i -> i == dims ? UnitRange(1, 1) : UnitRange(r[i]), N)
+
+    d[r1...] = view(a, r0...) .- view(a, r1...)
+    d[d1...] = view(a, d0...) .- view(a, d1...)
+
+    return d
+end
+
+function forwarddiff!(d::AbstractArray{T,N}, a::AbstractArray{T,N}; dims::Int) where {T,N}
+    require_one_based_indexing(a)
+    1 <= dims <= N || throw(ArgumentError("dimension $dims out of range (1:$N)"))
+
+    r = axes(a)
+    r0 = ntuple(i -> i == dims ? UnitRange(1, last(r[i]) - 1) : UnitRange(r[i]), N)
+    r1 = ntuple(i -> i == dims ? UnitRange(2, last(r[i])) : UnitRange(r[i]), N)
+
+    d0 = ntuple(i -> i == dims ? UnitRange(last(r[i]), last(r[i])) : UnitRange(r[i]), N)
+    d1 = ntuple(i -> i == dims ? UnitRange(1, 1) : UnitRange(r[i]), N)
+
+    d[r0...] = view(a, r1...) .- view(a, r0...)
+    d[d0...] = view(a, d1...) .- view(a, d0...)
+
+    return d
+end
+
+function backdiff!(d::AbstractArray{T,N}, a::AbstractArray{T,N}; dims::Int) where {T,N}
+    require_one_based_indexing(a)
+    1 <= dims <= N || throw(ArgumentError("dimension $dims out of range (1:$N)"))
+
+    r = axes(a)
+    r0 = ntuple(i -> i == dims ? UnitRange(1, last(r[i]) - 1) : UnitRange(r[i]), N)
+    r1 = ntuple(i -> i == dims ? UnitRange(2, last(r[i])) : UnitRange(r[i]), N)
+
+    d0 = ntuple(i -> i == dims ? UnitRange(last(r[i]), last(r[i])) : UnitRange(r[i]), N)
+    d1 = ntuple(i -> i == dims ? UnitRange(1, 1) : UnitRange(r[i]), N)
+
+    d[r1...] = view(a, r0...) .- view(a, r1...)
+    d[d1...] = view(a, d0...) .- view(a, d1...)
+
+    return d
+end
+
+# Docstrings
+
+"""
+    forwarddiff(a::AbstractArray{T,N}; dims::Int) where {T,N}
+
+Finite one-dimension forward difference operator on a vector or a multidimensional array `A`. In both cases,
+the dimension to operate on needs to be specified with the `dims` keyword argument.
+
+# Output
+
+The return `Vector` or `Array` maintains the same size as input.
+
+# Examples
+
+```julia
+julia> A = [2 4 8; 3 9 27; 4 16 64]
+3×3 Matrix{Int64}:
+ 2   4   8
+ 3   9  27
+ 4  16  64
+
+julia> forwarddiff(A, dims=2)
+3×3 Matrix{Int64}:
+  2   4   -6
+  6  18  -24
+ 12  48  -60
+```
+
+See also [`forwarddiff!`](@ref) for in-place forward difference.
+"""
+forwarddiff
+
+"""
+    forwarddiff!(d::AbstractArray{T,N}, a::AbstractArray{T,N}; dims::Int) where {T,N}}
+
+Finite one-dimension forward difference operator on a vector or a multidimensional array `A`. In both cases,
+the dimension to operate on needs to be specified with the `dims` keyword argument.
+
+# Output
+
+`d` will be changed in place. The return `Vector` or `Array` maintains the same size as input.
+
+# Examples
+
+```julia
+julia> A = [2 4 8; 3 9 27; 4 16 64]
+3×3 Matrix{Int64}:
+ 2   4   8
+ 3   9  27
+ 4  16  64
+
+julia> D = similar(A)
+3×3 Matrix{Int64}:
+ 140441636044112  140441636135216  140441696235920
+ 140441647064848  140441636135296  140441636135456
+ 140441636135136  140441636135376  140441636135056
+
+julia> forwarddiff!(D, A, dims=2)
+3×3 Matrix{Int64}:
+  2   4   -6
+  6  18  -24
+ 12  48  -60
+
+julia> D
+3×3 Matrix{Int64}:
+  2   4   -6
+  6  18  -24
+ 12  48  -60
+```
+
+See also: [`forwarddiff`](@ref)
+"""
+forwarddiff!
+
+"""
+    backdiff(a::AbstractArray{T,N}; dims::Int) where {T,N}
+
+Finite one-dimension backward difference operator on a vector or a multidimensional array `A`. In both cases,
+the dimension to operate on needs to be specified with the `dims` keyword argument.
+
+# Output
+
+The return `Vector` or `Array` maintains the same size as input.
+
+# Examples
+
+```julia
+julia> A = [2 4 8; 3 9 27; 4 16 64]
+3×3 Matrix{Int64}:
+ 2   4   8
+ 3   9  27
+ 4  16  64
+
+julia> backdiff(A, dims=2)
+3×3 Matrix{Int64}:
+  6   -2   -4
+ 24   -6  -18
+ 60  -12  -48
+```
+
+See also [`backdiff!`](@ref) for in-place backward difference.
+"""
+backdiff
+
+"""
+    backdiff!(d::AbstractArray{T,N}, a::AbstractArray{T,N}; dims::Int) where {T,N}}
+
+Finite one-dimension backward difference operator on a vector or a multidimensional array `A`. In both cases,
+the dimension to operate on needs to be specified with the `dims` keyword argument.
+
+# Output
+
+`d` will be changed in place. The return `Vector` or `Array` maintains the same size as input.
+
+# Examples
+
+```julia
+julia> A = [2 4 8; 3 9 27; 4 16 64]
+3×3 Matrix{Int64}:
+ 2   4   8
+ 3   9  27
+ 4  16  64
+
+julia> D = similar(A)
+3×3 Matrix{Int64}:
+ 140103024112336  140103024112336  140103027568240
+               0                0                0
+ 140103024361232  140103024361232  140103024361232
+
+julia> backdiff!(D, A, dims=2)
+3×3 Matrix{Int64}:
+  6   -2   -4
+ 24   -6  -18
+ 60  -12  -48
+
+julia> D
+3×3 Matrix{Int64}:
+  6   -2   -4
+ 24   -6  -18
+ 60  -12  -48
+```
+
+See also: [`backdiff`](@ref)
+"""
+backdiff!

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -80,15 +80,19 @@ function fdiff!(dst::AbstractArray, src::AbstractArray;
         dst[r1...] .= view(src, r1...) .- view(src, r0...)
         if boundary == :periodic
             dst[d1...] .= view(src, d1...) .- view(src, d0...)
-        else
+        elseif boundary == :zero
             dst[d1...] .= zero(eltype(dst))
+        else
+            throw(ArgumentError("Wrong boundary condition $boundary"))
         end
     else
         dst[r0...] .= view(src, r1...) .- view(src, r0...)
         if boundary == :periodic
             dst[d0...] .= view(src, d1...) .- view(src, d0...)
-        else
+        elseif boundary == :zero
             dst[d0...] .= zero(eltype(dst))
+        else
+            throw(ArgumentError("Wrong boundary condition $boundary"))
         end
     end
 

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -55,11 +55,11 @@ function fdiff!(dst::AbstractArray, src::AbstractArray; dims=_fdiff_default_dims
     d1 = ntuple(i -> i == dims ? UnitRange(first(r[i]), first(r[i])) : UnitRange(r[i]), N)
 
     if rev
-        dst[r1...] = view(src, r0...) .- view(src, r1...)
-        dst[d1...] = view(src, d0...) .- view(src, d1...)
+        dst[r1...] .= view(src, r0...) .- view(src, r1...)
+        dst[d1...] .= view(src, d0...) .- view(src, d1...)
     else
-        dst[r0...] = view(src, r1...) .- view(src, r0...)
-        dst[d0...] = view(src, d1...) .- view(src, d0...)
+        dst[r0...] .= view(src, r1...) .- view(src, r0...)
+        dst[d0...] .= view(src, d1...) .- view(src, d0...)
     end
 
     return dst

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -11,7 +11,8 @@ Take vector as an example, it computes `(A[2]-A[1], A[3]-A[2], ..., A[1]-A[end])
 # Keywords
 
 - `rev::Bool`
-  If `rev==true`, then it computes reversely `(A[end]-A[1], A[1]-A[2], ..., A[end-1]-A[end])`.
+  If `rev==true`, then it computes the backward difference
+  `(A[end]-A[1], A[1]-A[2], ..., A[end-1]-A[end])`.
 - `boundary`
   By default it computes periodically in the boundary, i.e., `:periodic`.
   In some cases, one can fill zero values with `boundary=:zero`.
@@ -39,9 +40,9 @@ julia> fdiff(A, dims=2)
 
 julia> fdiff(A, dims=2, rev=true) # reverse diff
 3×3 $(Matrix{Int}):
-  6   -2   -4
- 24   -6  -18
- 60  -12  -48
+  -6   2   4
+ -24   6  18
+ -60  12  48
 
 julia> fdiff(A, dims=2, boundary=:zero) # fill boundary with zeros
 3×3 $(Matrix{Int}):
@@ -62,7 +63,7 @@ The in-place version of [`ImageBase.fdiff`](@ref)
 function fdiff!(dst::AbstractArray, src::AbstractArray;
         dims=_fdiff_default_dims(src),
         rev=false,
-        boundary=:periodic)
+        boundary::Symbol=:periodic)
     isnothing(dims) && throw(UndefKeywordError(:dims))
     axes(dst) == axes(src) || throw(ArgumentError("axes of all input arrays should be equal. Instead they are $(axes(dst)) and $(axes(src))."))
     N = ndims(src)
@@ -76,9 +77,9 @@ function fdiff!(dst::AbstractArray, src::AbstractArray;
     d1 = ntuple(i -> i == dims ? UnitRange(first(r[i]), first(r[i])) : UnitRange(r[i]), N)
 
     if rev
-        dst[r1...] .= view(src, r0...) .- view(src, r1...)
+        dst[r1...] .= view(src, r1...) .- view(src, r0...)
         if boundary == :periodic
-            dst[d1...] .= view(src, d0...) .- view(src, d1...)
+            dst[d1...] .= view(src, d1...) .- view(src, d0...)
         else
             dst[d1...] .= zero(eltype(dst))
         end

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -25,7 +25,7 @@ julia> A = [2 4 8; 3 9 27; 4 16 64]
  3   9  27
  4  16  64
 
-julia> diff(A, dims=2)
+julia> diff(A, dims=2) # this function exists in Base
 3×2 $(Matrix{Int}):
   2   4
   6  18
@@ -36,6 +36,18 @@ julia> fdiff(A, dims=2)
   2   4   -6
   6  18  -24
  12  48  -60
+
+julia> fdiff(A, dims=2, rev=true) # reverse diff
+3×3 $(Matrix{Int}):
+  6   -2   -4
+ 24   -6  -18
+ 60  -12  -48
+
+julia> fdiff(A, dims=2, boundary=:zero) # fill boundary with zeros
+3×3 $(Matrix{Int}):
+  2   4  0
+  6  18  0
+ 12  48  0
 ```
 
 See also [`fdiff!`](@ref) for the in-place version.

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -33,6 +33,20 @@
         fdiff!(out, a, dims = 2, rev=true)
         @test out == b_bd_2
 
+        @testset "Boundary" begin
+            # These originally lives in Images and we use it to check the compatibility
+            forwarddiffy(u::AbstractMatrix) = [u[2:end,:]; u[end:end,:]] - u
+            forwarddiffx(u::AbstractMatrix) = [u[:,2:end] u[:,end:end]] - u
+            backdiffy(u::AbstractMatrix) = u - [u[1:1,:]; u[1:end-1,:]]
+            backdiffx(u::AbstractMatrix) = u - [u[:,1:1] u[:,1:end-1]]
+
+            X = rand(3, 3)
+            @test forwarddiffx(X) == fdiff(X, dims=2, boundary=:zero)
+            @test forwarddiffy(X) == fdiff(X, dims=1, boundary=:zero)
+            @test backdiffx(X) == .-fdiff(X, dims=2, rev=true, boundary=:zero)
+            @test backdiffy(X) == .-fdiff(X, dims=1, rev=true, boundary=:zero)
+        end
+
         # check numerical results with base implementation
         drop_last_slice(X, dims) = collect(StackView(collect(eachslice(X, dims=dims))[1:end-1]..., dims=dims))
         function drop_last_slice(X::AbstractVector, dims)

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -16,8 +16,8 @@
         a = reshape(collect(1:9), 3, 3)
         b_fd_1 = [1 1 1; 1 1 1; -2 -2 -2]
         b_fd_2 = [3 3 -6; 3 3 -6; 3 3 -6]
-        b_bd_1 = [2 2 2; -1 -1 -1; -1 -1 -1]
-        b_bd_2 = [6 -3 -3; 6 -3 -3; 6 -3 -3]
+        b_bd_1 = [-2 -2 -2; 1 1 1; 1 1 1]
+        b_bd_2 = [-6 3 3; -6 3 3; -6 3 3]
         out = similar(a)
 
         @test fdiff(a, dims = 1) == b_fd_1
@@ -43,8 +43,8 @@
             X = rand(3, 3)
             @test forwarddiffx(X) == fdiff(X, dims=2, boundary=:zero)
             @test forwarddiffy(X) == fdiff(X, dims=1, boundary=:zero)
-            @test backdiffx(X) == .-fdiff(X, dims=2, rev=true, boundary=:zero)
-            @test backdiffy(X) == .-fdiff(X, dims=1, rev=true, boundary=:zero)
+            @test backdiffx(X) == fdiff(X, dims=2, rev=true, boundary=:zero)
+            @test backdiffy(X) == fdiff(X, dims=1, rev=true, boundary=:zero)
         end
 
         # check numerical results with base implementation
@@ -69,7 +69,7 @@
                 out = fdiff(A; dims=dims)
                 @test out_base == drop_last_slice(out, dims)
 
-                out_base = reverse(diff(reverse(A; dims=dims); dims=dims); dims=dims)
+                out_base = .-reverse(diff(reverse(A; dims=dims); dims=dims); dims=dims)
                 out = fdiff(A; dims=dims, rev=true)
                 @test out_base == drop_first_slice(out, dims)
             end

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -10,6 +10,12 @@
         mat_out = similar(mat_in)
         fdiff!(mat_out, mat_in, dims = 3, rev=true)
         @test mat_out == fdiff(mat_in, dims = 3, rev=true)
+
+        # default `dims` are only available when input is a vector
+        v = rand(9)
+        @test fdiff(v) == fdiff(v; dims=1)
+        m = rand(3, 3)
+        @test_throws UndefKeywordError fdiff(m)
     end
 
     @testset "NumericalTests" begin

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -1,16 +1,15 @@
-@testset "forwarddiff and backwarddiff" begin
+@testset "fdiff" begin
     @testset "API" begin
-        # forwarddiff! works the same as forwarddiff
+        # fdiff! works the same as fdiff
         mat_in = rand(3, 3, 3)
         mat_out = similar(mat_in)
-        ImageBase.forwarddiff!(mat_out, mat_in, dims = 2)
-        @test mat_out == ImageBase.forwarddiff(mat_in, dims = 2)
+        fdiff!(mat_out, mat_in, dims = 2)
+        @test mat_out == fdiff(mat_in, dims = 2)
 
-        # backdiff! works the same as backdiff
         mat_in = rand(3, 3, 3)
         mat_out = similar(mat_in)
-        ImageBase.backdiff!(mat_out, mat_in, dims = 3)
-        @test mat_out == ImageBase.backdiff(mat_in, dims = 3)
+        fdiff!(mat_out, mat_in, dims = 3, rev=true)
+        @test mat_out == fdiff(mat_in, dims = 3, rev=true)
     end
 
     @testset "NumericalTests" begin
@@ -21,17 +20,57 @@
         b_bd_2 = [6 -3 -3; 6 -3 -3; 6 -3 -3]
         out = similar(a)
 
-        @test ImageBase.forwarddiff(a, dims = 1) == b_fd_1
-        @test ImageBase.forwarddiff(a, dims = 2) == b_fd_2
-        @test ImageBase.backdiff(a, dims = 1) == b_bd_1
-        @test ImageBase.backdiff(a, dims = 2) == b_bd_2
-        ImageBase.forwarddiff!(out, a, dims = 1)
+        @test fdiff(a, dims = 1) == b_fd_1
+        @test fdiff(a, dims = 2) == b_fd_2
+        @test fdiff(a, dims = 1, rev=true) == b_bd_1
+        @test fdiff(a, dims = 2, rev=true) == b_bd_2
+        fdiff!(out, a, dims = 1)
         @test out == b_fd_1
-        ImageBase.forwarddiff!(out, a, dims = 2)
+        fdiff!(out, a, dims = 2)
         @test out == b_fd_2
-        ImageBase.backdiff!(out, a, dims = 1)
+        fdiff!(out, a, dims = 1, rev=true)
         @test out == b_bd_1
-        ImageBase.backdiff!(out, a, dims = 2)
+        fdiff!(out, a, dims = 2, rev=true)
         @test out == b_bd_2
+
+        # check numerical results with base implementation
+        drop_last_slice(X, dims) = collect(StackView(collect(eachslice(X, dims=dims))[1:end-1]..., dims=dims))
+        function drop_last_slice(X::AbstractVector, dims)
+            @assert dims==1
+            X[1:end-1]
+        end
+        drop_first_slice(X, dims) = collect(StackView(collect(eachslice(X, dims=dims))[2:end]..., dims=dims))
+        function drop_first_slice(X::AbstractVector, dims)
+            @assert dims==1
+            X[2:end]
+        end
+
+        for N in 1:3
+            sz = ntuple(_->5, N)
+            A = rand(sz...)
+            A_out = similar(A)
+            
+            for dims = 1:N
+                out_base = diff(A; dims=dims)
+                out = fdiff(A; dims=dims)
+                @test out_base == drop_last_slice(out, dims)
+
+                out_base = reverse(diff(reverse(A; dims=dims); dims=dims); dims=dims)
+                out = fdiff(A; dims=dims, rev=true)
+                @test out_base == drop_first_slice(out, dims)
+            end
+        end
+    end
+
+    @testset "OffsetArrays" begin
+        A = OffsetArray(rand(3, 3), -1, -1)
+        A_out = fdiff(A, dims=1)
+        @test axes(A_out) == (0:2, 0:2)
+        @test A_out.parent == fdiff(parent(A), dims=1)
+
+        A = OffsetArray(rand(3, 3), -1, -1)
+        A_out = fdiff(A, dims=1, rev=true)
+        @test axes(A_out) == (0:2, 0:2)
+        @test A_out.parent == fdiff(parent(A), dims=1, rev=true)
     end
 end

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -1,0 +1,37 @@
+@testset "forwarddiff and backwarddiff" begin
+    @testset "API" begin
+        # forwarddiff! works the same as forwarddiff
+        mat_in = rand(3, 3, 3)
+        mat_out = similar(mat_in)
+        ImageBase.forwarddiff!(mat_out, mat_in, dims = 2)
+        @test mat_out == ImageBase.forwarddiff(mat_in, dims = 2)
+
+        # backdiff! works the same as backdiff
+        mat_in = rand(3, 3, 3)
+        mat_out = similar(mat_in)
+        ImageBase.backdiff!(mat_out, mat_in, dims = 3)
+        @test mat_out == ImageBase.backdiff(mat_in, dims = 3)
+    end
+
+    @testset "NumericalTests" begin
+        a = reshape(collect(1:9), 3, 3)
+        b_fd_1 = [1 1 1; 1 1 1; -2 -2 -2]
+        b_fd_2 = [3 3 -6; 3 3 -6; 3 3 -6]
+        b_bd_1 = [2 2 2; -1 -1 -1; -1 -1 -1]
+        b_bd_2 = [6 -3 -3; 6 -3 -3; 6 -3 -3]
+        out = similar(a)
+
+        @test ImageBase.forwarddiff(a, dims = 1) == b_fd_1
+        @test ImageBase.forwarddiff(a, dims = 2) == b_fd_2
+        @test ImageBase.backdiff(a, dims = 1) == b_bd_1
+        @test ImageBase.backdiff(a, dims = 2) == b_bd_2
+        ImageBase.forwarddiff!(out, a, dims = 1)
+        @test out == b_fd_1
+        ImageBase.forwarddiff!(out, a, dims = 2)
+        @test out == b_fd_2
+        ImageBase.backdiff!(out, a, dims = 1)
+        @test out == b_bd_1
+        ImageBase.backdiff!(out, a, dims = 2)
+        @test out == b_bd_2
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,19 @@
-using ImageBase, ImageCore, OffsetArrays
-using Test, TestImages
+using ImageBase, OffsetArrays, StackViews
+using Test, TestImages, Aqua, Documenter
 
 using OffsetArrays: IdentityUnitRange
 
 @testset "ImageBase.jl" begin
+
+    @testset "Project meta quality checks" begin
+        # Not checking compat section for test-only dependencies
+        Aqua.test_all(ImageBase; project_extras=true, deps_compat=true, stale_deps=true, project_toml_formatting=true)
+        if VERSION >= v"1.2"
+            doctest(ImageBase, manual = false)
+        end
+    end
+    
+    include("diff.jl")
     include("restrict.jl")
 
     @info "deprecations are expected"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,9 +7,20 @@ using OffsetArrays: IdentityUnitRange
 
     @testset "Project meta quality checks" begin
         # Not checking compat section for test-only dependencies
-        Aqua.test_all(ImageBase; project_extras=true, deps_compat=true, stale_deps=true, project_toml_formatting=true)
+        ambiguity_exclude_list = [
+            # https://github.com/JuliaDiff/ChainRulesCore.jl/pull/367#issuecomment-869071000
+            Base.:(==),
+        ]
+        Aqua.test_ambiguities([ImageCore, Base, Core], exclude=ambiguity_exclude_list)
+        Aqua.test_all(ImageBase;
+            ambiguities=false,
+            project_extras=true,
+            deps_compat=true,
+            stale_deps=true,
+            project_toml_formatting=true
+        )
         if VERSION >= v"1.2"
-            doctest(ImageBase, manual = false)
+            doctest(ImageBase,manual = false)
         end
     end
     


### PR DESCRIPTION
This originally lives in [Images `src/algorithms`](https://github.com/JuliaImages/Images.jl/blob/e14a49f3057af969fd026cfd86ab8960d7838ecf/src/algorithms.jl#L499-L504). During the development of another ROF-like algorithm in https://github.com/johnnychen94/ImageSmooth.jl/pull/1, we've identified that the performance can be boosted a lot by removing unnecessary memory allocations.

Improvements to the original version:

- support arbitrary dimension
- support offset arrays
- use `rev` keyword to control whether it is a forward difference (`rev=false` default) or a reverse difference (`rev=true`)
- similar to `diff`, vector input for `fdiff` now have `dims=1` by default.

@JKay0327 the first commit 75174b3 is a copy & paste of your version, and then I did some refactoring on top of it, you can take a look at this and maybe get some idea of how expressive Julia can be :)

---

After this, we can then deprecate those `forwarddiffx` variants in Images https://github.com/JuliaImages/Images.jl/blob/e14a49f3057af969fd026cfd86ab8960d7838ecf/src/Images.jl#L149-L152

```julia
# correctness tests are added as test cases
julia> X = rand(100, 100);

julia> @btime fdiff($X, dims=1);
  4.397 μs (2 allocations: 78.17 KiB)

julia> @btime forwarddiffy($X);
  27.586 μs (7 allocations: 234.64 KiB)
```