### PR TITLE
Added varfinite

### DIFF
--- a/src/ImageBase.jl
+++ b/src/ImageBase.jl
@@ -14,7 +14,8 @@ export
     minfinite,
     maxfinite,
     maxabsfinite,
-    meanfinite
+    meanfinite,
+    varfinite
 
 
 using Reexport

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -72,9 +72,21 @@ Compute the variance of `A`, ignoring any non-finite values.
 
 The supported `kwargs` are those of `sum(f, A; kwargs...)`.
 """
-function varfinite(A; kwargs...)
-    m = meanfinite(A; kwargs...)
-    n = sum(Map12(isfinite, x->true, x->false), A; kwargs...)   # TODO: replace with `Returns`
-    s = sum(Map12(isfinite, identity, zero), (A .- m).^2; kwargs...)
-    return s ./ (n .- 1)
+function varfinite end
+
+if Base.VERSION >= v"1.1"
+    function varfinite(A; kwargs...)
+        m = meanfinite(A; kwargs...)
+        n = sum(Map12(isfinite, x->true, x->false), A; kwargs...)   # TODO: replace with `Returns`
+        s = sum(Map12(isfinite, identity, zero), (A .- m).^2; kwargs...)
+        return s ./ (n .- 1)
+    end
+else
+    function varfinite(A; kwargs...)
+        m = meanfinite(A; kwargs...)
+        n = sum(Map12(isfinite, x->true, x->false).(A); kwargs...) 
+        s = sum(Map12(isfinite, identity, zero).((A .- m).^2); kwargs...)
+        return s ./ (n .- 1)
+    end
 end
+    

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -79,14 +79,14 @@ if Base.VERSION >= v"1.1"
         m = meanfinite(A; kwargs...)
         n = sum(Map12(isfinite, x->true, x->false), A; kwargs...)   # TODO: replace with `Returns`
         s = sum(Map12(isfinite, identity, zero), (A .- m).^2; kwargs...)
-        return s ./ (n .- 1)
+        return s ./ max.(0, (n .- 1))
     end
 else
     function varfinite(A; kwargs...)
         m = meanfinite(A; kwargs...)
         n = sum(Map12(isfinite, x->true, x->false).(A); kwargs...) 
         s = sum(Map12(isfinite, identity, zero).((A .- m).^2); kwargs...)
-        return s ./ (n .- 1)
+        return s ./ max.(0, (n .- 1))
     end
 end
     

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -64,3 +64,17 @@ else
         return s./n
     end
 end
+
+"""
+    varfinite(A; kwargs...)
+
+Compute the variance of `A`, ignoring any non-finite values.
+
+The supported `kwargs` are those of `sum(f, A; kwargs...)`.
+"""
+function varfinite(A; kwargs...)
+    m = meanfinite(A; kwargs...)
+    n = sum(Map12(isfinite, x->true, x->false), A; kwargs...)   # TODO: replace with `Returns`
+    s = sum(Map12(isfinite, identity, zero), (A .- m).^2; kwargs...)
+    return s ./ (n .- 1)
+end

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -9,20 +9,25 @@ using Test
     img = colorview(RGB, PermutedDimsArray(A, (3,1,2)))
     s12 = sum(img, dims=(1,2))
     @test eltype(s12) <: RGB
+
     A = [NaN, 1, 2, 3]
-    @test meanfinite(A, 1) ≈ [2]
+    @test meanfinite(A, dims=1) ≈ [2]
     @test varfinite(A, dims=1) ≈ [1]
+
     A = [NaN 1 2 3;
          NaN 6 5 4]
-    mf = meanfinite(A, 1)
+    mf = meanfinite(A, dims=1)
     vf = varfinite(A, dims=1)
     @test isnan(mf[1])
     @test mf[1,2:end] ≈ [3.5,3.5,3.5]
     @test vf[1,:] ≈ [0,12.5,4.5,0.5]
-    @test meanfinite(A, 2) ≈ reshape([2, 5], 2, 1)
+
+    @test meanfinite(A, dims=2) ≈ reshape([2, 5], 2, 1)
     @test varfinite(A, dims=2) ≈ reshape([1, 1], 2, 1)
-    @test meanfinite(A, (1,2)) ≈ [3.5]
+
+    @test meanfinite(A, dims=(1,2)) ≈ [3.5]
     @test varfinite(A, dims=(1,2)) ≈ [3.5]
+
     @test minfinite(A) == 1
     @test maxfinite(A) == 6
     @test maxabsfinite(A) == 6
@@ -34,7 +39,7 @@ using Test
     @test maxfinite(A) == maximum(A)
     A = rand(Float32,3,5,5)
     img = colorview(RGB, A)
-    dc = meanfinite(img, 1)-reshape(reinterpretc(RGB{Float32}, mean(A, dims=2)), (1,5))
+    dc = meanfinite(img, dims=1)-reshape(reinterpretc(RGB{Float32}, mean(A, dims=2)), (1,5))
     @test maximum(map(_abs, dc)) < 1e-6
     dc = minfinite(img)-RGB{Float32}(minimum(A, dims=(2,3))...)
     @test _abs(dc) < 1e-6

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -14,13 +14,19 @@ using Test
     @test meanfinite(A, dims=1) ≈ [2]
     @test varfinite(A, dims=1) ≈ [1]
 
+    A = [NaN NaN 1;
+        1 2 3]
+    vf = varfinite(A, dims=2)
+    @test isnan(vf[1])
+
     A = [NaN 1 2 3;
          NaN 6 5 4]
     mf = meanfinite(A, dims=1)
     vf = varfinite(A, dims=1)
     @test isnan(mf[1])
-    @test mf[1,2:end] ≈ [3.5,3.5,3.5]
-    @test vf[1,:] ≈ [0,12.5,4.5,0.5]
+    @test mf[2:end] ≈ [3.5,3.5,3.5]
+    @test isnan(vf[1]) 
+    @test vf[2:end] ≈ [12.5,4.5,0.5]
 
     @test meanfinite(A, dims=2) ≈ reshape([2, 5], 2, 1)
     @test varfinite(A, dims=2) ≈ reshape([1, 1], 2, 1)

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -11,13 +11,18 @@ using Test
     @test eltype(s12) <: RGB
     A = [NaN, 1, 2, 3]
     @test meanfinite(A, 1) ≈ [2]
+    @test varfinite(A, dims=1) ≈ [1]
     A = [NaN 1 2 3;
          NaN 6 5 4]
     mf = meanfinite(A, 1)
+    vf = varfinite(A, dims=1)
     @test isnan(mf[1])
     @test mf[1,2:end] ≈ [3.5,3.5,3.5]
+    @test vf[1,:] ≈ [0,12.5,4.5,0.5]
     @test meanfinite(A, 2) ≈ reshape([2, 5], 2, 1)
+    @test varfinite(A, dims=2) ≈ reshape([1, 1], 2, 1)
     @test meanfinite(A, (1,2)) ≈ [3.5]
+    @test varfinite(A, dims=(1,2)) ≈ [3.5]
     @test minfinite(A) == 1
     @test maxfinite(A) == 6
     @test maxabsfinite(A) == 6


### PR DESCRIPTION
Reimplemented stdfinite suggested [here](https://github.com/JuliaImages/Images.jl/pull/980#issuecomment-919491264) as varfinite using the new style (which does look a lot better).

Checked and the new method is about twice as fast on a 50x60x70 array and allocates about 30% less memory. 

I've also updated the tests for meanfinite, changing `meanfinite(A, region)` to `meanfinite(A, dims=region)`, to stop the depreciation warnings during the tests. I've put these in a different commit in case these it was meant to be that way (apologies if that is the case).

Thanks!