### PR TITLE
Rename `Map12` -> `IfElse`

### DIFF
--- a/src/ImageBase.jl
+++ b/src/ImageBase.jl
@@ -26,6 +26,7 @@ using ImageCore.OffsetArrays
 
 include("diff.jl")
 include("restrict.jl")
+include("utils.jl")
 include("statistics.jl")
 include("compat.jl")
 include("deprecated.jl")

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1,28 +1,11 @@
 """
-    Map12(condition, f1, f2)
-
-Creates a function mapping `x -> condition(x) ? f1(x) : f2(x)`.
-"""
-struct Map12{C,F1,F2}
-    condition::C
-    f1::F1
-    f2::F2
-end
-(m::Map12)(x) = m.condition(x) ? m.f1(x) : m.f2(x)
-
-minc(x, y) = min(x, y)
-minc(x::Color, y::Color) = mapc(min, x, y)
-maxc(x, y) = max(x, y)
-maxc(x::Color, y::Color) = mapc(max, x, y)
-
-"""
     minfinite(A; kwargs...)
 
 Calculate the minimum value in `A`, ignoring any values that are not finite (Inf or NaN).
 
 The supported `kwargs` are those of `minimum(f, A; kwargs...)`.
 """
-minfinite(A; kwargs...) = mapreduce(Map12(isfinite, identity, typemax), minc, A; kwargs...)
+minfinite(A; kwargs...) = mapreduce(IfElse(isfinite, identity, typemax), minc, A; kwargs...)
 
 """
     maxfinite(A; kwargs...)
@@ -31,7 +14,7 @@ Calculate the maximum value in `A`, ignoring any values that are not finite (Inf
 
 The supported `kwargs` are those of `maximum(f, A; kwargs...)`.
 """
-maxfinite(A; kwargs...) = mapreduce(Map12(isfinite, identity, typemin), maxc, A; kwargs...)
+maxfinite(A; kwargs...) = mapreduce(IfElse(isfinite, identity, typemin), maxc, A; kwargs...)
 
 """
     maxabsfinite(A; kwargs...)
@@ -40,7 +23,7 @@ Calculate the maximum absolute value in `A`, ignoring any values that are not fi
 
 The supported `kwargs` are those of `maximum(f, A; kwargs...)`.
 """
-maxabsfinite(A; kwargs...) = mapreduce(Map12(isfinite, abs, typemin), maxc, A; kwargs...)
+maxabsfinite(A; kwargs...) = mapreduce(IfElse(isfinite, abs, typemin), maxc, A; kwargs...)
 
 """
     meanfinite(A; kwargs...)
@@ -53,14 +36,14 @@ function meanfinite end
 
 if Base.VERSION >= v"1.1"
     function meanfinite(A; kwargs...)
-        s = sum(Map12(isfinite, identity, zero), A; kwargs...)
-        n = sum(Map12(isfinite, x->true, x->false), A; kwargs...)   # TODO: replace with `Returns`
+        s = sum(IfElse(isfinite, identity, zero), A; kwargs...)
+        n = sum(IfElse(isfinite, x->true, x->false), A; kwargs...)   # TODO: replace with `Returns`
         return s./n
     end
 else
     function meanfinite(A; kwargs...)
-        s = sum(Map12(isfinite, identity, zero).(A); kwargs...)
-        n = sum(Map12(isfinite, x->true, x->false).(A); kwargs...)
+        s = sum(IfElse(isfinite, identity, zero).(A); kwargs...)
+        n = sum(IfElse(isfinite, x->true, x->false).(A); kwargs...)
         return s./n
     end
 end
@@ -77,16 +60,15 @@ function varfinite end
 if Base.VERSION >= v"1.1"
     function varfinite(A; kwargs...)
         m = meanfinite(A; kwargs...)
-        n = sum(Map12(isfinite, x->true, x->false), A; kwargs...)   # TODO: replace with `Returns`
-        s = sum(Map12(isfinite, identity, zero), (A .- m).^2; kwargs...)
+        n = sum(IfElse(isfinite, x->true, x->false), A; kwargs...)   # TODO: replace with `Returns`
+        s = sum(IfElse(isfinite, identity, zero), (A .- m).^2; kwargs...)
         return s ./ max.(0, (n .- 1))
     end
 else
     function varfinite(A; kwargs...)
         m = meanfinite(A; kwargs...)
-        n = sum(Map12(isfinite, x->true, x->false).(A); kwargs...) 
-        s = sum(Map12(isfinite, identity, zero).((A .- m).^2); kwargs...)
+        n = sum(IfElse(isfinite, x->true, x->false).(A); kwargs...)
+        s = sum(IfElse(isfinite, identity, zero).((A .- m).^2); kwargs...)
         return s ./ max.(0, (n .- 1))
     end
 end
-    

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,19 @@
+"""
+    IfElse(condition, f1, f2)
+
+Create a function mapping `x -> condition(x) ? f1(x) : f2(x)`.
+
+This is essentially the same as the anonymous function, but more
+interpretable in stacktraces and more amenable to precompilation.
+"""
+struct IfElse{C,F1,F2}
+    condition::C
+    f1::F1
+    f2::F2
+end
+(m::IfElse)(x) = m.condition(x) ? m.f1(x) : m.f2(x)
+
+minc(x, y) = min(x, y)
+minc(x::Color, y::Color) = mapc(min, x, y)
+maxc(x, y) = max(x, y)
+maxc(x::Color, y::Color) = mapc(max, x, y)


### PR DESCRIPTION
This is like a functional form of `ifelse`, so perhaps we should rename it. It's purely internal, so this is just cosmetic and not important whatever gets decided.

CC @jagoosw, who just had to decipher its meaning, for a viewpoint.