### PR TITLE
[compat] update to ImageCore 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "ImageBase"
 uuid = "c817782e-172a-44cc-b673-b171935fbb9e"
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-ImageCore = "0.9.3"
+ImageCore = "0.10"
 Reexport = "0.2, 1"
 julia = "1"
 


### PR DESCRIPTION
This will fail tests until the [extras] also get bumped. Tested locally and passes if all a `dev`ed.